### PR TITLE
Fixed mdns2 version to build on recent version of OSX 

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "midi-common": "*"
   },
   "optionalDependencies": {
-    "mdns2": "2.x",
+    "mdns2": "2.2.10",
     "avahi_pub": "TheThingSystem/node_avahi_pub"
   },
   "keywords": [


### PR DESCRIPTION
It previously did not.

2.x resolves to 2.1.4 by npm, which does not build :-1: 